### PR TITLE
Fix: manifest.json github link typo for catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ It shall NOT be edited by hand.
 
 # Huginn for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/huginn.svg)](https://dash.yunohost.org/appci/app/huginn) ![Working status](https://ci-apps.yunohost.org/ci/badges/huginn.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/huginn.maintain.svg)  
+[![Integration level](https://dash.yunohost.org/integration/huginn.svg)](https://dash.yunohost.org/appci/app/huginn) ![Working status](https://ci-apps.yunohost.org/ci/badges/huginn.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/huginn.maintain.svg)
+
 [![Install Huginn with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=huginn)
 
 *[Lire ce readme en français.](./README_fr.md)*
@@ -26,7 +27,7 @@ Huginn is a system for building agents that perform automated tasks for you onli
 ## Documentation and resources
 
 * Upstream app code repository: <https://github.com/huginn/huginn>
-* YunoHost documentation for this app: <https://yunohost.org/app_huginn>
+* YunoHost Store: <https://apps.yunohost.org/app/huginn>
 * Report a bug: <https://github.com/YunoHost-Apps/huginn_ynh/issues>
 
 ## Developer info

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,28 +5,29 @@ It shall NOT be edited by hand.
 
 # Huginn pour YunoHost
 
-[![Niveau d'intégration](https://dash.yunohost.org/integration/huginn.svg)](https://dash.yunohost.org/appci/app/huginn) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/huginn.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/huginn.maintain.svg)  
+[![Niveau d’intégration](https://dash.yunohost.org/integration/huginn.svg)](https://dash.yunohost.org/appci/app/huginn) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/huginn.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/huginn.maintain.svg)
+
 [![Installer Huginn avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=huginn)
 
 *[Read this readme in english.](./README.md)*
 
-> *Ce package vous permet d'installer Huginn rapidement et simplement sur un serveur YunoHost.
-Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour savoir comment l'installer et en profiter.*
+> *Ce package vous permet d’installer Huginn rapidement et simplement sur un serveur YunoHost.
+Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour savoir comment l’installer et en profiter.*
 
-## Vue d'ensemble
+## Vue d’ensemble
 
 Huginn is a system for building agents that perform automated tasks for you online. They can read the web, watch for events, and take actions on your behalf. Huginn's Agents create and consume events, propagating them along a directed graph. Think of it as a hackable version of IFTTT or Zapier on your own server. You always know who has your data. You do.
 
 **Version incluse :** 2022.03.24~ynh3
 
-## Captures d'écran
+## Captures d’écran
 
-![Capture d'écran de Huginn](./doc/screenshots/your-agents.png)
+![Capture d’écran de Huginn](./doc/screenshots/your-agents.png)
 
 ## Documentations et ressources
 
-* Dépôt de code officiel de l'app : <https://github.com/huginn/huginn>
-* Documentation YunoHost pour cette app : <https://yunohost.org/app_huginn>
+* Dépôt de code officiel de l’app : <https://github.com/huginn/huginn>
+* YunoHost Store: <https://apps.yunohost.org/app/huginn>
 * Signaler un bug : <https://github.com/YunoHost-Apps/huginn_ynh/issues>
 
 ## Informations pour les développeurs
@@ -41,4 +42,4 @@ ou
 sudo yunohost app upgrade huginn -u https://github.com/YunoHost-Apps/huginn_ynh/tree/testing --debug
 ```
 
-**Plus d'infos sur le packaging d'applications :** <https://yunohost.org/packaging_apps>
+**Plus d’infos sur le packaging d’applications :** <https://yunohost.org/packaging_apps>

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": " Build agents that monitor and act on your behalf. Your agents are standing by!"
     },
     "version": "2022.03.24~ynh3",
-    "url": "https://github.com/huginn/hugin",
+    "url": "https://github.com/huginn/huginn",
     "upstream": {
         "license": "MIT",
         "code": "https://github.com/huginn/huginn"


### PR DESCRIPTION
## Problem

Github link in catalog 404s because it's missing an `n`

## Solution

- Fixed typo

## PR Status

- [X] Code finished and ready to be reviewed/tested
